### PR TITLE
feat(route): support multiple more Request APIs

### DIFF
--- a/src/WS/WSClient.ts
+++ b/src/WS/WSClient.ts
@@ -117,10 +117,10 @@ export default class WSClient {
       this.statusResolve = null;
       return;
     }
-    let body: Blob | undefined;
+    let body: ArrayBuffer | undefined;
     if (meta.hasBody) {
       this.bypassNextMessage = true;
-      body = await new Promise<Blob>((resolve) => {
+      const bodyBlob = await new Promise<Blob>((resolve) => {
         this.ws.addEventListener('message', (bodyEvent) => {
           if (!(bodyEvent.data instanceof Blob)) {
             throw new TypeError(`Expecting blob request body, received: ${String(bodyEvent.data)}`);
@@ -128,6 +128,7 @@ export default class WSClient {
           resolve(bodyEvent.data);
         }, { once: true });
       });
+      body = await bodyBlob.arrayBuffer();
     }
     const request = new RouteRequest(meta, body ?? null);
     const route = new Route(this.ws, meta.id, request);

--- a/src/WS/WSServer.ts
+++ b/src/WS/WSServer.ts
@@ -192,6 +192,7 @@ export default class WSServer {
         headersArray,
         isNavigationRequest: request.isNavigationRequest(),
         method: request.method(),
+        resourceType: request.resourceType(),
         url: request.url(),
       }));
       if (hasBody) {

--- a/src/WS/message.ts
+++ b/src/WS/message.ts
@@ -8,6 +8,7 @@ export interface RouteRequestMeta extends RouteMetaBase {
   headersArray: { name: string, value: string }[];
   isNavigationRequest: boolean;
   method: string;
+  resourceType: string;
   url: string;
 }
 

--- a/src/WS/route/Route.ts
+++ b/src/WS/route/Route.ts
@@ -7,7 +7,7 @@ export type FallbackOverrides = {
   url?: string;
   method?: string;
   headers?: Record<string, string>;
-  postData?: string | ArrayBufferLike | Blob | ArrayBufferView | null;
+  postData?: string | ArrayBuffer | ArrayBufferView;
 };
 
 export default class Route {


### PR DESCRIPTION
* add `routeRequest.headerValue(name: string)`, `routeRequest.postData()`, `routeRequest.postDataJSON()`, `routeRequest.postDataArrayBuffer()`, `routeRequest.resourceType()`
* remove `routeRequest.postDataBlob()`
* limit `postData` option in `route.continue` and `route.fallback` to `string | ArrayBuffer | ArrayBufferView`