### PR TITLE
feat(runner): more flexible watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,9 @@ wrightplay -w
 wrightplay --watch
 ```
 
-Watch the setup and test files for changes and automatically rerun the tests. Defaults to `false`.
+Monitor test file changes and trigger automatic test reruns. Defaults to `false`.
+
+Please be aware that on certain platforms, particularly in the context of large-scale projects, this feature might silently fail or raise some errors.
 
 ### browser
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "commander": "^11.1.0",
         "esbuild": "~0.19.5",
         "get-port": "^7.0.0",
+        "glob-parent": "^6.0.2",
         "globby": "^13.2.2",
         "jiti": "^1.20.0",
         "lilconfig": "^2.1.0",
@@ -26,7 +27,9 @@
         "wrightplay": "build/cli.js"
       },
       "devDependencies": {
+        "@types/glob-parent": "^5.1.2",
         "@types/mocha": "^10.0.3",
+        "@types/node": "^20.8.8",
         "@types/tape": "^5.6.3",
         "@types/ws": "^8.5.8",
         "@typescript-eslint/eslint-plugin": "^6.8.0",
@@ -790,6 +793,12 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-hS9aA7+fMXnKSOftFd1CSPJ9n4zrmYoQptBxr7NHYYUV+I9WXcU891jsihXWOv00tkiIcF0DviR378ZCzy1EQw==",
+      "dev": true
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -833,10 +842,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-      "dev": true
+      "version": "20.8.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.8.tgz",
+      "integrity": "sha512-YRsdVxq6OaLfmR9Hy816IMp33xOBjfyOgUd77ehqg96CFywxAPbDbXvAsuN2KVg2HOT8Eh6uAfU+l4WffwPVrQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.4",
@@ -2614,7 +2626,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -4878,6 +4889,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "dev": true
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5601,6 +5618,12 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-hS9aA7+fMXnKSOftFd1CSPJ9n4zrmYoQptBxr7NHYYUV+I9WXcU891jsihXWOv00tkiIcF0DviR378ZCzy1EQw==",
+      "dev": true
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -5644,10 +5667,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-      "dev": true
+      "version": "20.8.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.8.tgz",
+      "integrity": "sha512-YRsdVxq6OaLfmR9Hy816IMp33xOBjfyOgUd77ehqg96CFywxAPbDbXvAsuN2KVg2HOT8Eh6uAfU+l4WffwPVrQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.25.1"
+      }
     },
     "@types/semver": {
       "version": "7.5.4",
@@ -6963,7 +6989,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "requires": {
         "is-glob": "^4.0.3"
       }
@@ -8560,6 +8585,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "commander": "^11.1.0",
     "esbuild": "~0.19.5",
     "get-port": "^7.0.0",
+    "glob-parent": "^6.0.2",
     "globby": "^13.2.2",
     "jiti": "^1.20.0",
     "lilconfig": "^2.1.0",
@@ -78,7 +79,9 @@
     "ws": "^8.14.2"
   },
   "devDependencies": {
+    "@types/glob-parent": "^5.1.2",
     "@types/mocha": "^10.0.3",
+    "@types/node": "^20.8.8",
     "@types/tape": "^5.6.3",
     "@types/ws": "^8.5.8",
     "@typescript-eslint/eslint-plugin": "^6.8.0",

--- a/src/TestFinder.ts
+++ b/src/TestFinder.ts
@@ -1,0 +1,195 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { globby } from 'globby';
+import globParent from 'glob-parent';
+
+import './util/patchDisposable.js';
+import EventEmitter from './util/TypedEventEmitter.js';
+
+export interface TestFinderOptions {
+  patterns: string | readonly string[];
+  cwd: string;
+  watch?: boolean;
+}
+
+export interface TestFinderEventMap {
+  change: [];
+}
+
+export default class TestFinder extends EventEmitter<TestFinderEventMap> implements Disposable {
+  private readonly patterns: string | readonly string[];
+
+  private readonly cwd: string;
+
+  private readonly watch: boolean;
+
+  private readonly patternDirs: string[] = [];
+
+  private readonly patternWatcherMap = new Map<string, fs.FSWatcher>();
+
+  constructor({
+    patterns,
+    cwd,
+    watch = false,
+  }: TestFinderOptions) {
+    super();
+    this.patterns = patterns.concat(); // clone
+    this.cwd = cwd;
+    this.watch = watch;
+
+    if (watch) {
+      this.filesPromise = Promise.resolve([]);
+    } else {
+      this.filesPromise = this.searchFiles();
+      return;
+    }
+
+    // Parse pattern dirs to watch recursively
+    let patternDirs: string[] = [];
+    const patternList = (typeof patterns === 'string' ? [patterns] : patterns);
+    patternList.forEach((pattern) => {
+      // Skip negated patterns
+      if (pattern.startsWith('!')) return;
+
+      // Resolve its parent absolute dir path
+      const candidateDir = path.resolve(cwd, globParent(pattern));
+
+      // Skip if the pattern dir is already covered
+      if (patternDirs.some((dir) => candidateDir.startsWith(dir))) return;
+
+      // Remove dirs that will be covered by the candidate dir
+      patternDirs = patternDirs.filter((dir) => !dir.startsWith(candidateDir));
+
+      // Accept the candidate dir
+      patternDirs.push(candidateDir);
+    });
+
+    this.patternDirs = patternDirs;
+
+    // Create pattern watchers
+    this.patternWatcherMap = new Map(
+      Array.from(patternDirs, (dir) => {
+        const watcher = fs.watch(dir, {
+          persistent: false,
+          recursive: true,
+        });
+
+        watcher.on('change', this.onChange);
+
+        return [dir, watcher];
+      }),
+    );
+  }
+
+  private filesPromise: Promise<string[]>;
+
+  private searchFiles() {
+    return globby(this.patterns, {
+      cwd: this.cwd,
+      absolute: true,
+      gitignore: true,
+    });
+  }
+
+  /**
+   * Update the test file list.
+   * - In non-watch mode,
+   *   - is automatically called once when constructed.
+   *   - should be manually called to update the files.
+   * - In watch mode,
+   *   - should be manually called once before getting the files.
+   *   - is automatically called on file changes.
+   */
+  updateFiles() {
+    this.filesPromise = this.searchFiles().then((files) => {
+      this.emit('change');
+      return files;
+    });
+  }
+
+  /**
+   * Returns a promise that resolves to the list by the last `updateFiles` call.
+   */
+  getFiles() {
+    return this.filesPromise;
+  }
+
+  private relevantWatcherMap = new Map<string, fs.FSWatcher>();
+
+  /**
+   * Set additional files to watch.
+   * Each call will replace the previous provided files.
+   */
+  setRelevantFiles(files: string[]) {
+    if (!this.watch) {
+      throw new Error('Cannot set relevant files when not watching');
+    }
+
+    const lastWatcherMap = this.relevantWatcherMap;
+    const watcherMap = new Map<string, fs.FSWatcher>();
+    files.forEach((file) => {
+      // Use the parent dir to reduce the number of watchers.
+      const dir = path.dirname(path.resolve(this.cwd, file));
+
+      let watcher = lastWatcherMap.get(dir);
+
+      // reuse the existing watcher if possible
+      if (watcher) {
+        watcherMap.set(dir, watcher);
+        lastWatcherMap.delete(dir);
+        return;
+      }
+
+      // return if already watched by another relevant file
+      if (watcherMap.has(dir)) {
+        return;
+      }
+
+      // return if already watched by a pattern
+      if (this.patternDirs.some((patternDir) => dir.startsWith(patternDir))) {
+        return;
+      }
+
+      // create a new watcher if not watched by any other
+      watcher = fs.watch(dir, {
+        persistent: false,
+        recursive: false, // Yap, not recursive.
+      });
+
+      watcher.on('change', this.onChange);
+
+      watcherMap.set(dir, watcher);
+    });
+
+    lastWatcherMap.forEach((watcher) => {
+      watcher.close();
+    });
+
+    this.relevantWatcherMap = watcherMap;
+  }
+
+  private atomicTimeoutId: NodeJS.Timeout | null = null;
+
+  private onChange = () => {
+    if (this.atomicTimeoutId !== null) {
+      return;
+    }
+
+    this.atomicTimeoutId = setTimeout(() => {
+      this.atomicTimeoutId = null;
+      this.updateFiles();
+    }, 100);
+  };
+
+  [Symbol.dispose]() {
+    if (!this.watch) return;
+
+    this.patternWatcherMap.forEach((watcher) => {
+      watcher.close();
+    });
+
+    this.relevantWatcherMap.forEach((watcher) => {
+      watcher.close();
+    });
+  }
+}

--- a/src/WS/WSClient.ts
+++ b/src/WS/WSClient.ts
@@ -80,7 +80,7 @@ export default class WSClient {
     return this.statusPromise;
   }
 
-  bypassFetch(...fetchArgs: Parameters<typeof fetch>) {
+  bypassFetch(...fetchArgs: Parameters<WindowOrWorkerGlobalScope['fetch']>) {
     const request = new Request(...fetchArgs);
     request.headers.set(`bypass-${this.uuid}`, 'true');
     return fetch(request);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,7 +79,8 @@ program
     const runnerOptionsList = await parseRunnerOptionsFromCLI(testAndEntries, options);
     await runnerOptionsList.reduce(async (last, runnerOptions) => {
       await last;
-      const exitCode = await new Runner(runnerOptions).runTests();
+      using runner = new Runner(runnerOptions);
+      const exitCode = await runner.runTests();
       process.exitCode ||= exitCode;
     }, Promise.resolve());
   })

--- a/src/util/TypedEventEmitter.ts
+++ b/src/util/TypedEventEmitter.ts
@@ -1,0 +1,40 @@
+/* eslint-disable max-len */
+import { EventEmitter as BaseEventEmitter } from 'node:events';
+
+// The values of the event map are the arguments passed to the event.
+export type EventMap<T extends EventMap<T>> = Record<EventOf<T>, unknown[]>;
+
+// Extract valid event names from an event map.
+export type EventOf<T extends EventMap<T>> = Extract<keyof T, EventName>;
+
+// The base EventEmitter only allows string | symbol as event names.
+export type EventName = string | symbol;
+
+export type ArbitraryEventMap = Record<EventName, unknown[]>;
+
+export interface EventEmitter<T extends EventMap<T> = ArbitraryEventMap> extends BaseEventEmitter {
+  addListener<K extends EventOf<T>>(eventName: K, listener: (...args: T[K]) => void): this;
+  on<K extends EventOf<T>>(eventName: K, listener: (...args: T[K]) => void): this;
+  once<K extends EventOf<T>>(eventName: K, listener: (...args: T[K]) => void): this;
+  removeListener<K extends EventOf<T>>(eventName: K, listener: (...args: T[K]) => void): this;
+  off<K extends EventOf<T>>(eventName: K, listener: (...args: T[K]) => void): this;
+  removeAllListeners<K extends EventOf<T>>(event?: K): this;
+  listeners<K extends EventOf<T>>(eventName: K): ((...args: T[K]) => void)[];
+  rawListeners<K extends EventOf<T>>(eventName: K): ((...args: T[K]) => void)[];
+  emit<K extends EventOf<T>>(eventName: K, ...args: T[K]): boolean;
+  listenerCount<K extends EventOf<T>>(eventName: K): number;
+  prependListener<K extends EventOf<T>>(eventName: K, listener: (...args: T[K]) => void): this;
+  prependOnceListener<K extends EventOf<T>>(eventName: K, listener: (...args: T[K]) => void): this;
+  eventNames(): Array<EventOf<T>>;
+}
+
+export interface EventEmitterConstructor {
+  new <T extends EventMap<T> = ArbitraryEventMap>(...args: ConstructorParameters<typeof BaseEventEmitter>): EventEmitter<T>;
+  readonly prototype: EventEmitter<ArbitraryEventMap>;
+}
+
+// @ts-expect-error not assignable as we add type restrictions
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EventEmitter: EventEmitterConstructor = BaseEventEmitter;
+
+export default EventEmitter;

--- a/src/util/patchDisposable.ts
+++ b/src/util/patchDisposable.ts
@@ -1,0 +1,8 @@
+/**
+ * Simple polyfill that covers the `using` and `async using` use cases.
+ */
+
+// @ts-expect-error polyfill
+Symbol.dispose ??= Symbol('Symbol.dispose');
+// @ts-expect-error polyfill
+Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose');


### PR DESCRIPTION
The previous watch mode would throw an error if a test file was deleted, and the mode was implemented using the esbuild watch API, which unfortunately does not monitor the creation of new test files.

This PR introduces a custom file watcher that comprehensively handles the creation, modification, and deletion of most test files and imported files.
