### PR TITLE
fix(runner): minimize wrightplay pollution

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,9 +415,10 @@ import 'mocha';
 import { onInit, done } from 'wrightplay';
 
 mocha.setup({
-  ui: 'bdd',
-  reporter: 'spec',
   color: true,
+  fullTrace: true,
+  reporter: 'spec',
+  ui: 'bdd',
 });
 
 onInit(() => {

--- a/src/server/BrowserLogger.ts
+++ b/src/server/BrowserLogger.ts
@@ -174,10 +174,14 @@ export default class BrowserLogger {
         originalColumn,
       } = sourceMap.findEntry(+line - 1, +column - 1);
 
-      // The type of `findEntry` is loose. It may return {}.
-      return originalSource !== undefined
-        ? `${pathToFileURL(path.resolve(cwd, originalSource)).href}:${originalLine + 1}:${originalColumn + 1}`
-        : original;
+      // The return type of `findEntry` is inaccurate. It may return {}.
+      if (originalSource === undefined) {
+        return original;
+      }
+
+      const baseDir = path.join(cwd, path.dirname(pathname));
+      const originalSourcePath = path.resolve(baseDir, originalSource);
+      return `${pathToFileURL(originalSourcePath).href}:${originalLine + 1}:${originalColumn + 1}`;
     });
   }
 

--- a/src/server/BrowserLogger.ts
+++ b/src/server/BrowserLogger.ts
@@ -188,6 +188,13 @@ export default class BrowserLogger {
   lastPrint: Promise<void> = Promise.resolve();
 
   /**
+   * Discard the last print error.
+   */
+  discardLastPrintError() {
+    this.lastPrint = this.lastPrint.catch(() => {});
+  }
+
+  /**
    * Print messages to console with specified log level and color.
    */
   printWithOptions(

--- a/src/server/Runner.ts
+++ b/src/server/Runner.ts
@@ -256,8 +256,13 @@ export default class Runner implements Disposable {
           setup: (pluginBuild) => {
             pluginBuild.onResolve({ filter: /^<stdin>$/ }, () => ({ path: 'stdin', namespace: 'wrightplay' }));
             pluginBuild.onLoad({ filter: /^/, namespace: 'wrightplay' }, async () => {
+              // Sort to make the output stable
               const importFiles = await testFinder.getFiles();
+              importFiles.sort();
+
+              // Prepend the setup file if any
               if (setupFile) importFiles.unshift(setupFile.replace(/\\/g, '\\\\'));
+
               if (importFiles.length === 0) {
                 if (watch) {
                   // eslint-disable-next-line no-console
@@ -266,6 +271,7 @@ export default class Runner implements Disposable {
                   throw new Error('No test file found');
                 }
               }
+
               const importStatements = importFiles.map((file) => `import '${file}'`).join('\n');
               return {
                 contents: `${importStatements}\n(${clientRunner.init.toString()})('${this.uuid}')`,

--- a/test/default.setup.ts
+++ b/test/default.setup.ts
@@ -14,9 +14,10 @@ const {
   const { onInit, done } = await import('../src/client/api.js');
 
   mocha.setup({
-    ui: 'bdd',
-    reporter: 'spec',
     color: true,
+    fullTrace: true,
+    reporter: 'spec',
+    ui: 'bdd',
   });
 
   onInit(() => {

--- a/test/third-party/mocha/setup.ts
+++ b/test/third-party/mocha/setup.ts
@@ -2,9 +2,10 @@ import 'mocha';
 import { onInit, done } from 'wrightplay';
 
 mocha.setup({
-  ui: 'bdd',
-  reporter: 'spec',
   color: true,
+  fullTrace: true,
+  reporter: 'spec',
+  ui: 'bdd',
 });
 
 onInit(() => {


### PR DESCRIPTION
* Fix the source-mapped stack traces for entry points that is not a direct child of cwd.
* Move wrightplay entry point to `__wrightplay__/stdin`.
* Remove the injected script element once it starts to load.
* Discard log errors that is caused by auto rerun navigations.
* Sort test imports to ignore irrelevant file watch events.
* Suggest the `fullTrace` option for mocha use cases.